### PR TITLE
Fix display getting stuck in BUSY state

### DIFF
--- a/rpi_epd2in7/epd.py
+++ b/rpi_epd2in7/epd.py
@@ -205,7 +205,11 @@ class EPD(object):
 
     def wait_until_idle(self):
         """ Wait until screen is idle by polling the busy pin """
+        # HACK: fix e-Paper not picking up ready signal and getting stuck in busy state
+        # https://github.com/waveshare/e-Paper/issues/30#issuecomment-640254220
+        self.send_command(0x71)
         while(self.digital_read(BUSY_PIN) == 0):      # 0: busy, 1: idle
+            self.send_command(0x71)
             self.delay_ms(50)
 
     def reset(self):


### PR DESCRIPTION
These issues cover a possible scenario where the ePaper display can get stuck in BUSY state:
- https://github.com/waveshare/e-Paper/issues/30#issuecomment-640254220
- https://github.com/waveshare/e-Paper/issues/80

I have the Waveshare 2.7in HAT version and can consistently reproduce with your library:
[reproduce.log](https://github.com/elad661/rpi_epd2in7/files/7150313/reproduce.log)
[reproduce_2.log.txt](https://github.com/elad661/rpi_epd2in7/files/7150327/reproduce_2.log.txt)
[reproduce_3.log.txt](https://github.com/elad661/rpi_epd2in7/files/7150328/reproduce_3.log.txt)


The workaround is described here https://github.com/waveshare/e-Paper/issues/30#issuecomment-640254220

Adding the workaround ensures the display exits its BUSY state. Here is the log, I stopped the log after 32 draws:
[with_fix.log](https://github.com/elad661/rpi_epd2in7/files/7150332/with_fix.log)


This isn't to fix the root of the problem but I propose to add these changes so this library can be used by others in long-running tasks where the display is refreshed frequently.
